### PR TITLE
firmware: fx2: drop deprecated sdcclib

### DIFF
--- a/firmware/fx2/Makefile.am
+++ b/firmware/fx2/Makefile.am
@@ -239,11 +239,11 @@ $(dirstamps):
 
 fx2lib/lib/fx2.lib: $(fx2lib_objects)
 	-$(AM_V_at)rm -f $@
-	$(AM_V_GEN)$(SDCCLIB) $@ $(fx2lib_objects)
+	$(AM_V_GEN)$(SDAR) -rc $@ $(fx2lib_objects)
 
 fx2lib/lib/interrupts/ints.lib: $(fx2lib_ints_objects)
 	-$(AM_V_at)rm -f $@
-	$(AM_V_GEN)$(SDCCLIB) $@ $(fx2lib_ints_objects)
+	$(AM_V_GEN)$(SDAR) -rc $@ $(fx2lib_ints_objects)
 
 fx2adf435xfw.ihx: $(fx2adf435xfw_objects) $(fx2lib_libs)
 	$(AM_V_GEN)$(SDCC) -mmcs51 $(SDCC_LINK_FLAGS) -o $@ $(fx2adf435xfw_objects) $(fx2lib_libs)

--- a/firmware/fx2/configure.ac
+++ b/firmware/fx2/configure.ac
@@ -36,9 +36,9 @@ AC_CHECK_PROGS([SDCC], [sdcc sdcc-sdcc])
 AS_IF([test "x$SDCC" = x],
 	[AC_MSG_ERROR([cannot find sdcc.])])
 
-AC_CHECK_PROGS([SDCCLIB], [sdcclib sdcc-sdcclib])
-AS_IF([test "x$SDCCLIB" = x],
-	[AC_MSG_ERROR([cannot find sdcclib.])])
+AC_CHECK_PROGS([SDAR], [sdar sdcc-sdar])
+AS_IF([test "x$SDAR" = x],
+	[AC_MSG_ERROR([cannot find sdar.])])
 
 sf_sdcc_version=`$SDCC --version | sed -n 's/.* \([[0-9]][[0-9]]*\.[[0-9]][[0-9]]*\.[[0-9]][[0-9]]*\) .*/\1/p;q' 2>&AS_MESSAGE_LOG_FD`
 AS_VERSION_COMPARE([$sf_sdcc_version], [2.9.0],


### PR DESCRIPTION
sdcclib has been deprecated for quite some time now and is missing in the
latest sdcc release, it should be replaced by sdar.

Signed-off-by: Filipe Laíns <lains@archlinux.org>