### PR TITLE
Add support the Bus Pirate interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ The software suite consists of the following components:
 * **stm32adf435xfw**  - A similar firmware for the STM32F103.
 
 
+It's also possible to use the [Bus Pirate](http://dangerousprototypes.com/docs/Bus_Pirate) as the interface for the ``SPI``
+communications, simply using the ``adf435x.interfaces.BusPirate`` class.
+
 adf435x
 -------
 

--- a/adf435x/interfaces.py
+++ b/adf435x/interfaces.py
@@ -16,8 +16,13 @@
 ## You should have received a copy of the GNU General Public License
 ## along with this program; if not, see <http://www.gnu.org/licenses/>.
 ##
-
+import logging
+import struct
 import usb.core
+
+
+logger = logging.getLogger(__name__)
+
 
 class FX2:
     def __init__(self):
@@ -33,3 +38,38 @@ class FX2:
         for reg in regs:
             self.dev.ctrl_transfer(bmRequestType=0x40, bRequest=0xDD, wValue=0, wIndex=0,
                 data_or_wLength=[(reg >> (8 * b)) & 0xFF for b in range(4)])
+
+
+class BusPirate:
+    """This interface communicates via serial port using the pyBusPirateLite
+    module and translate the command in native SPI."""
+
+    def __init__(self, device='/dev/ttyUSB0', baudrate=115200):
+        """Initialize the interface for the Bus Pirate using "device"
+        with the given "baudrate"."""
+        from pyBusPirateLite.SPI import SPI
+
+        self.spi = SPI(device, baudrate)
+
+        # speed = 30kHz
+        # polarity = idle low (default)
+        # output clock edge = active to idle (default)
+        # input sample phase = middle (default)
+        # CS = /CS (default)
+        # output type = normal
+
+        self.spi.pins = SPI.PIN_POWER | SPI.PIN_CS | SPI.PIN_AUX
+        self.spi.config = SPI.CFG_PUSH_PULL | SPI.CFG_CLK_EDGE
+        self.spi.speed = '30kHz'
+
+    def write_data(self, data):
+        """Write a single integer value (4 bytes) into the SPI bus."""
+        data = struct.pack('>I', data)
+        logger.debug(['%02x' % d for d in data])
+        self.spi.cs = True
+        self.spi.transfer(data)
+        self.spi.cs = False
+
+    def set_regs(self, regs):
+        for reg in regs:
+            self.write_data(reg)


### PR DESCRIPTION
Bus Pirate is a well-known tool for hardware hackers that allows to easily interface to raw protocols (official page [here](http://dangerousprototypes.com/docs/Bus_Pirate)).

I didn't add the dependencies for the pyBusPirateLite library in ``setup.py``, I think is possible to indicate specific dependencies only when necessary, if you want I can add that.